### PR TITLE
Patch 2 list

### DIFF
--- a/public/src/components/chat.js
+++ b/public/src/components/chat.js
@@ -58,7 +58,7 @@ export default React.createClass({
       type: 'text',
       ref: 'entry',
       onKeyDown: this.key,
-      placeholder: '/nick name'
+      placeholder: 'type "/nick YourName"'
     })
   },
 

--- a/public/src/components/deck-settings.js
+++ b/public/src/components/deck-settings.js
@@ -25,7 +25,7 @@ function Lands() {
   })
 
   let suggest = d.tr({},
-    d.td({}, 'deck size'),
+    d.td({}, 'Deck size '),
     d.td({}, d.input({
       className: 'number',
       min: 0,
@@ -36,11 +36,11 @@ function Lands() {
     d.td({ colSpan: 2 }, d.button({
       className: 'land-suggest-button',
       onClick: App._emit('resetLands')
-    }, 'reset lands')),
+    }, 'Reset lands')),
     d.td({ colSpan: 2 }, d.button({
       className: 'land-suggest-button',
       onClick: App._emit('suggestLands')
-    }, 'suggest lands')))
+    }, 'Suggest lands')))
 
   return d.fieldset({ className: 'land-controls fieldset' },
     d.legend({ className: 'legend game-legend' }, 'Lands'),

--- a/public/src/components/game.js
+++ b/public/src/components/game.js
@@ -72,10 +72,10 @@ export default React.createClass({
     if (App.state.type !== 'sealed' && App.state.type !== 'cube sealed') {
       startControls = d.div({},
         d.div({}, `Format: ${App.state.format}`),
-        LBox('addBots', 'bots'),
+        LBox('addBots', 'Bots'),
         d.div({},
           d.label({},
-            LBox('useTimer', 'timer: '),
+            LBox('useTimer', 'Timer: '),
             d.label({},
               d.select({
                 disabled: !App.state.useTimer,
@@ -99,11 +99,11 @@ export default React.createClass({
   Players() {
     let rows = App.state.players.map(row)
     let columns = [
-      d.th({}, '#'),
+      d.th({}, 'Seat'),
       d.th({}, ''), // connection status
-      d.th({}, 'name'),
-      d.th({}, 'packs'),
-      d.th({}, 'time'),
+      d.th({}, 'Name'),
+      d.th({}, 'Packs'),
+      d.th({}, 'Time'),
       d.th({}, 'cock'),
       d.th({}, 'mws'),
     ]
@@ -197,7 +197,7 @@ function row(p, i) {
     if (i !== self && !p.isBot)
       columns.push(d.td({}, d.button({
         onClick: ()=> App.send('kick', i),
-      }, 'kick')))
+      }, 'Kick')))
     else
       columns.push(d.td({}))
 

--- a/public/src/components/lobby.js
+++ b/public/src/components/lobby.js
@@ -61,9 +61,9 @@ function content() {
   let setsFourTwo = d.div({}, sets.slice(2, 4))
 
   let cube = [
-    d.div({}, 'one card per line'),
+    d.div({}, 'Cube list:'),
     d.textarea({
-      placeholder: 'cube list',
+      placeholder: 'one card per line',
       valueLink: App.link('list')
     })
   ]
@@ -71,10 +71,10 @@ function content() {
   let cards = _.seq(15, 8).map(x => d.option({}, x))
   let packs = _.seq(12, 3).map(x => d.option({}, x))
   let cubeDraft = d.div({},
-    d.select({ valueLink: App.link('cards') }, cards),
-    ' cards ',
     d.select({ valueLink: App.link('packs') }, packs),
-    ' packs')
+    ' Packs  ')
+    d.select({ valueLink: App.link('cards') }, cards),
+    ' Cards',
   let chaos = d.div({})
   let fourPackBox = d.div({},RBox('fourPack', '4 Pack Sealed: '))
   let modernOnlyBox = d.div({},RBox('modernOnly', 'Only Modern Sets: '))
@@ -102,12 +102,12 @@ function Motd() {
 function ServerInfo() {
   let numUsers =
     `${App.state.numUsers}
-    ${App.state.numUsers === 1 ? 'user' : 'users'}
+    ${App.state.numUsers === 1 ? 'user' : 'Users'}
     connected`
 
   let numPlayers =
     `${App.state.numPlayers}
-    ${App.state.numPlayers === 1 ? 'player' : 'players'}
+    ${App.state.numPlayers === 1 ? 'player' : 'Players'}
     playing
     ${App.state.numActiveGames}
     ${App.state.numActiveGames === 1 ? 'game' : 'games'}`


### PR DESCRIPTION
missing
- sorting, `CMC` etc.
https://github.com/tooomm/dr4ft/blob/patch-2/public/src/components/game-settings.js#L9
- game types, `Draft` etc.
https://github.com/tooomm/dr4ft/blob/patch-2/public/src/components/lobby.js#L130
- add lands, where `Main` etc. - better full names?
https://github.com/tooomm/dr4ft/blob/patch-2/public/src/components/deck-settings.js#L11
- name of bots are `bot`
- player/game table not 100%
- check game info: format/type
- double check 2x added space, order flip
- tweak "this cube needs between 90 and 100,000 cards; it has 1" error msg (it shows also 1 if no card entered)
- move game type selector below headline
- add space between settings and sorting (make it completely separate?
- column titles bad (issue at dr4fter repo)

title case? mixed right now by several contributors
  